### PR TITLE
fixes no main manifest attribute,

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,4 +36,31 @@
             <version>2.15.3</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <configuration>
+                <archive>
+                <manifest>
+                    <mainClass>com.example.Main</mainClass>
+                </manifest>
+                </archive>
+                <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+            </configuration>
+            <executions>
+                <execution>
+                <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                <phase>package</phase> <!-- bind to the packaging phase -->
+                <goals>
+                    <goal>single</goal>
+                </goals>
+                </execution>
+            </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
 fixes no main manifest attribute, in target/jetty-mock-service-1.0-SNAPSHOT.jar

run:
mvn package
java -jar target/jetty-mock-service-1.0-SNAPSHOT-jar-with-dependencies.jar